### PR TITLE
build: add jenkinsfile and flake file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,55 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.9.13'
+
+pipeline {
+  agent { label 'linux' }
+
+  options {
+    disableConcurrentBuilds()
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(
+      numToKeepStr: '20',
+      daysToKeepStr: '30',
+    ))
+  }
+
+  environment {
+    GIT_COMMITTER_NAME = 'status-im-auto'
+    GIT_COMMITTER_EMAIL = 'auto@status.im'
+  }
+
+  stages {
+    stage('Install') {
+      steps {
+        nix.develop('yarn install')
+      }
+    }
+
+    stage('Build') {
+      steps {
+        script {
+          nix.develop('yarn build')
+          jenkins.genBuildMetaJSON('build/build.json')
+        }
+      }
+    }
+
+    stage('Publish') {
+      steps {
+        sshagent(credentials: ['status-im-auto-ssh']) {
+          nix.develop("""
+            ghp-import \
+              -b deploy-main \
+              -c docs.status.network \
+              -p build
+          """
+          )
+         }
+      }
+    }
+  }
+
+  post {
+    cleanup { cleanWs() }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Welcome to the official documentation for Status Network! This repository contai
 - [Yarn](https://yarnpkg.com/) (v1 or higher)
 - [Git](https://git-scm.com/)
 
+If you are familiar with using [Nix shell](https://nix.dev/manual/nix/2.17/command-ref/new-cli/nix3-develop) all of the dependencies will be installed by just running `nix develop` from within this repository which will spawn a new shell.
+
 ### Installation
 
 ```bash
@@ -39,6 +41,14 @@ yarn build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
+
+## CI/CD
+
+- [CI builds](https://ci.infra.status.im/job/website/job/docs.status.network/) `main` and pushes to `deploy-main` branch, which is hosted at <https://docs.status.network/>.
+
+The hosting is done using [Caddy server with Git plugin for handling GitHub webhooks](https://github.com/status-im/infra-misc/blob/master/ansible/roles/caddy-git).
+
+Information about deployed build can be also found in `/build.json` available on the website.
 
 ## 📝 Contributing
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729973466,
+        "narHash": "sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd3e8833d70618c4eea8df06f95b364b016d4950",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-24.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-24.05";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = forEachSystem (system: import nixpkgs { inherit system; });
+    in
+    rec {
+      formatter = forEachSystem (system: pkgsFor.${system}.nixpkgs-fmt);
+
+      devShells = forEachSystem (system: {
+        default = pkgsFor.${system}.mkShellNoCC {
+          packages = with pkgsFor.${system}.buildPackages; [
+            yarn # 1.22.22
+            nodejs_20 # v20.15.1
+            ghp-import # 2.1.0
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
To be able to deploy site we need a pipeline to build it and publish it to a branch from which our caddy-git service will pull for changes. All of this will be done using nix flake to ease out the build/development process.

Referenced issue: https://github.com/status-im/status-network-docs/issues/1

# What does this PR resolve? 🚀
- build of the website content which is needed for deploying it

# Details 📝
Added nix flake file which is used in the Jenkins pipeline but can be also used by developers by just issuing `nix develop` command within the repository. It  ensures consistency across environments by specifying exact dependencies and versions of packages.

# Checklist ✅
- [ ] I have merged the main branch into my branch and resolved all conflicts
- [ ] I have documented the new code
- [x] I have smoke tested the new code locally
- [x] I have assigned the PR to myself
- [x] I have named the PR correctly